### PR TITLE
Offene Fragen aus dem Dokument entfernt

### DIFF
--- a/dokument/master/chapter_6030.md
+++ b/dokument/master/chapter_6030.md
@@ -36,4 +36,4 @@ entsprechenden HTTPS-URLs eine der beiden folgenden Möglichkeiten gelten:
 * Entweder ist unter den entsprechenden HTTPS-URLs kein Webserver erreichbar
 
 * oder Anfragen an die HTTPS-URLs werden mit Redirects auf die entsprechenden
-  HTTP-URLs beantwortet (FRAGE: ist das ein sinnvolles Szenario?).
+  HTTP-URLs beantwortet.

--- a/dokument/master/chapter_6080.md
+++ b/dokument/master/chapter_6080.md
@@ -50,15 +50,11 @@ Beispiel:
 
     Content-Disposition: attachment; filename="2014-08-22 Rat Wortprotokoll.pdf"
 
-FRAGE: Sind in Dateinamen sinnvoll?
-
 Der in diesem Header kommunizierte Dateiname ist als Vorschlag an die Nutzerin
 zu verstehen, die Datei unter diesem Namen zu speichern. Entsprechend sind Abwägungen
 bezüglich der Verständlichkeit, Leserlichkeit und Einzigartigkeit des Dateinamens,
 aber auch in Hinblick auf den verwendeten Zeichenumfang zu berücksichtigen. Es
 wird EMPFOHLEN, den Dateinamen ausschließlich aus dem ASCII-Zeichenvorrat zu bilden.
-FRAGE: Ist die Beschränkung auf ASCII und damit der Verzicht z.B. auf Umlaute
-erforderlich?
 
 Im Unterschied zum Zugriff auf die Download-URL DARF der Server beim Zugriff auf die
 Zugriffs-URL KEINEN `Content-Disposition` Header mit Parameter `attachment`

--- a/dokument/master/chapter_8080.md
+++ b/dokument/master/chapter_8080.md
@@ -101,14 +101,12 @@ abgebildet.
 `chairPerson`
 :   Vorsitz der Sitzung
     Typ: `oparl:Person`.
-    FRAGE: Was ist bei Wechsel des Vorsitzes während der Sitzung?
     Kardinalität: 0 bis 1.
     EMPFOHLEN.
 
 `scribe`
 :   Schriftführer, Protokollant. 
     Typ: `oparl:Person`.
-    FRAGE: Können mehrere Personen vorkommen? Was ist bei Wechsel während der Sitzung?
     Kardinalität: 0 bis 1.
     EMPFOHLEN.
 
@@ -117,14 +115,12 @@ abgebildet.
     Bei einer Sitzung in der Zukunft sind dies die geladenen Teilnehmer, bei 
     einer stattgefundenen Sitzung SOLL die Liste nur diejenigen Teilnehmer umfassen,
     die tatsächlich an der Sitzung teilgenommen haben.
-    FRAGE: besser zwei separate Eigenschaften `attendant` und `ìnvited` ?
     Typ: Liste von Objekten des Typs `oparl:Person`. Vgl. [Objektlisten](#objektlisten).
     Kardinalität: 0 bis *.
     DEPRECATED.
 
 `invitation`
 :   Einladungsdokument zur Sitzung.
-    FRAGE: Kann es mehr als ein solches Dokument geben?
     Typ: Liste von Objekten des Typs `oparl:File`. Vgl. [Objektlisten](#objektlisten).
     Kardinalität: 0 bis *.
     EMPFOHLEN.

--- a/dokument/master/chapter_8090.md
+++ b/dokument/master/chapter_8090.md
@@ -57,7 +57,6 @@ Eigenschaft `consultation` referenziert werden kann.
 :   Beratung, die diesem Tagesordnungspunkt zugewiesen ist.
     Typ: URL eines Objekts vom Typ `oparl:Consultation`.
     Kardinalität: 0 bis 1.
-    FRAGE: Wirklich immer nur maximal 1 ?
     EMPFOHLEN.
 
 `result`


### PR DESCRIPTION
Offene Frage entfernt => Telko OParl Orga 02.12.2014 => Veränderungsnotwendigkeiten sollen sich aus dem Praxiseinsatz ergeben und als Anforderung an eine zukünftige Version aufgenommen werden.